### PR TITLE
Fixed a mistake in specifying of a remote port.

### DIFF
--- a/content/remote-development/forward-command.md
+++ b/content/remote-development/forward-command.md
@@ -24,7 +24,7 @@ mysql -h127.0.0.1 -u dbuser -pdbpass dbname
 You can specify a second port number if the remote port number is different to the local port number:
 
 ```
-cp-remote forward -s db 3307 3306
+cp-remote forward -s db 3307:3306
 ```
 
 Here the local port 3307 is forward to 3306 on the remote, you could then connect using:


### PR DESCRIPTION
Regarding to the help information `cp-remote forward -h`, local and remote ports must be delimited by a semicolon.